### PR TITLE
pkg/analyzer: change Doc

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -15,7 +15,9 @@ import (
 
 const (
 	Name = "grouper"
-	Doc  = `expression group analyzer: require 'import', 'const', 'var' and/or 'type' declaration groups`
+	Doc  = `analyze expression groups
+
+Require 'import', 'const', 'var' and/or 'type' declaration groups.`
 )
 
 func New() *analysis.Analyzer {


### PR DESCRIPTION
Change analyzer `Doc` field according to the [documentation](https://pkg.go.dev/golang.org/x/tools/go/analysis#Analyzer) and to be the same as in the [`golangci-lint` code](https://github.com/golangci/golangci-lint/blob/ce020c6be1b8f9da457436fa9b85f7f54f8107b7/pkg/golinters/grouper.go#L26).